### PR TITLE
Removed db_info_dict

### DIFF
--- a/kso_utils/spyfish_utils.py
+++ b/kso_utils/spyfish_utils.py
@@ -266,7 +266,7 @@ def process_spyfish_subjects(subjects: pd.DataFrame, db_path: str):
     subjects["#Subject_type"] = subjects["#Subject_type"].fillna(
         subjects["subject_type"]
     )
-    subjects["subject_type"] = subjects["Subject_type"].fillna(
+    subjects["subject_type"] = subjects["subject_type"].fillna(
         subjects["#Subject_type"]
     )
 


### PR DESCRIPTION
Used the features of the project class instead of calling the db_info_dict. I also removed the widget functions used in spyfish-specific tutorials as they are not longer needed.