### PR TITLE
fix: use always "koster" as team name (#85)

### DIFF
--- a/kso_utils/project.py
+++ b/kso_utils/project.py
@@ -1097,7 +1097,7 @@ class MLProjectProcessor(ProjectProcessor):
             g_utils.import_modules(["torch", "wandb", "yaml", "yolov5"], utils=False)
         )
 
-        self.team_name = self.get_team_name()
+        self.team_name = "koster"
 
         model_selected = t_utils.choose_model_type()
 


### PR DESCRIPTION
When the project name was "Spyfish_Aotearoa" the team name "wildlife-ai" was used before, since there was no project with that name in the "koster" team. However, recently a project called "Spyfish_Aotearoa"  was created in the "koster" team, so there is no need to make a distinction now.