### PR TITLE
fix: cleaned up the choose_workflows funct

### DIFF
--- a/kso_utils/project.py
+++ b/kso_utils/project.py
@@ -762,14 +762,7 @@ class ProjectProcessor:
             subject_type=workflow_checks["Subject type: #0"],
             selected_zoo_workflows=selected_zoo_workflows,
         )
-
-    def choose_workflows(self, generate_export: bool = False, zoo_cred=False):
-        zoo_utils.connect_zoo_project(
-            generate_export=generate_export, zoo_cred=zoo_cred
-        )
-        self.workflow_widget = zoo_utils.WidgetMaker(self.zoo_info["workflows"])
-        display(self.workflow_widget)
-
+    
     def aggregate_zoo_classifications(self, agg_params, test: bool = False):
         if test:
             workflow_checks = {


### PR DESCRIPTION
pylint highlighted issues with the duplication of the choose_workflows function so I removed the function from the project.py as we didn't use it in the tutorials and we already have one "choose_workflow" function in zooniverse_utils.